### PR TITLE
[BN-1488]: Create shared GitHub action to trigger docs portal deploy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Purpose
+
+## Approach
+
+## Testing
+
+## Tickets
+*
+
+
+**Delete everything after and including this line after you are done reading and understand what to put for each section**
+
+>### Purpose
+>
+>*State in plain words what the scope of the pull request and what problem it is trying to solve*
+>
+>### Approach
+>
+>*Enumerate the steps you took to create the code/changes contained in this pull request*
+>
+>### Testing
+>
+>*Specify all unit, integration, or end-to-end testing that is contained in this pull request*
+>
+>### Tickets
+>
+>*List tickets if any that are connected to this pull request in the following format:*
+>
+>_* closes #1234_

--- a/.github/workflows/trigger-docs-deploy.yaml
+++ b/.github/workflows/trigger-docs-deploy.yaml
@@ -30,11 +30,11 @@ jobs:
           # Set the required variables
           service=${{ github.event.inputs.target_service }}"
           version="${{ github.event.inputs.target_version }}"
-
+          branch="${{ github.ref_name }}"
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ inputs.repo_owner }}/${{ inputs.repo_name }}/dispatches \
-            -d "{\"event_type\": \"${{ inputs.event_type }}\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+            -d "{\"event_type\": \"${{ inputs.event_type }}\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"branch\": \"$branch\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/trigger-docs-deploy.yaml
+++ b/.github/workflows/trigger-docs-deploy.yaml
@@ -2,6 +2,17 @@ name: Apparatus Docs Deploy Trigger
 
 on:
   workflow_dispatch:
+    inputs:
+      repo_owner:
+        description: "Name of the GitHub repo owner/org. ex: Apparatus."
+        default: "Topl"
+        required: false
+        type: string
+      repo_name:
+        description: "Name of the GitHub repo. ex: Knowledge-Base."
+        default: "Knowledge-Base"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -12,8 +23,6 @@ jobs:
       - name: Trigger Workflow in Another Repository
         run: |
           # Set the required variables
-          repo_owner="Topl"
-          repo_name="Knowledge-Base"
           event_type="trigger-workflow"
           service=${{ github.event.inputs.target_service }}"
           version="${{ github.event.inputs.target_version }}"
@@ -23,5 +32,5 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            https://api.github.com/repos/${{ inputs.repo_owner }}/${{ inputs.repo_name }}/dispatches \
             -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/trigger-docs-deploy.yaml
+++ b/.github/workflows/trigger-docs-deploy.yaml
@@ -1,4 +1,4 @@
-name: Apparatus Docs Deploy Trigger
+name: Apparatus Repo Workflow Trigger
 
 on:
   workflow_dispatch:

--- a/.github/workflows/trigger-docs-deploy.yaml
+++ b/.github/workflows/trigger-docs-deploy.yaml
@@ -1,0 +1,27 @@
+name: Apparatus Docs Deploy Trigger
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Current API version can be found here: https://docs.github.com/en/rest/about-the-rest-api/api-versions?apiVersion=2022-11-28
+      - name: Trigger Workflow in Another Repository
+        run: |
+          # Set the required variables
+          repo_owner="Topl"
+          repo_name="Knowledge-Base"
+          event_type="trigger-workflow"
+          service=${{ github.event.inputs.target_service }}"
+          version="${{ github.event.inputs.target_version }}"
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/trigger-docs-deploy.yaml
+++ b/.github/workflows/trigger-docs-deploy.yaml
@@ -13,6 +13,11 @@ on:
         default: "Knowledge-Base"
         required: false
         type: string
+      event_type:
+        description: "Name of the event that triggers the repository_dispatch. Useful for selectively running dispatched workflows."
+        default: "trigger-workflow"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -23,7 +28,6 @@ jobs:
       - name: Trigger Workflow in Another Repository
         run: |
           # Set the required variables
-          event_type="trigger-workflow"
           service=${{ github.event.inputs.target_service }}"
           version="${{ github.event.inputs.target_version }}"
 
@@ -33,4 +37,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{ inputs.repo_owner }}/${{ inputs.repo_name }}/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+            -d "{\"event_type\": \"${{ inputs.event_type }}\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/trigger-docs-deploy.yaml
+++ b/.github/workflows/trigger-docs-deploy.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       event_type:
         description: "Name of the event that triggers the repository_dispatch. Useful for selectively running dispatched workflows."
-        default: "trigger-workflow"
+        default: "trigger_workflow"
         required: false
         type: string
 


### PR DESCRIPTION
## Purpose
For https://docs.apparatus.live, we want to keep the relevant documentation in each of the source repositories (Bifrost/Brambl-cli, BramblSc, etc).

We can use the Docusaurus remote content plugin to accomplish this, however we need to be able to detect when the docs are updated in the remote repos so that the central portal can rebuild and re-deploy.

We can accomplish this by using https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch

## Approach
* Create a shared GitHub action that can be used to trigger a workflow in another repo.
* Add an organization wide default pull request template.

### Notes
I still need to implement the "triggered" workflow on the Knowledge-Base side, and utilize it in each of the remote repos, but this PR is the first step to do so.

## Testing
I can't test this out until it's merged, and the triggered workflow for Knowledge-Base is merged into the main branch. :frowning: 

## Tickets
* BN-1488
